### PR TITLE
Fixed #12

### DIFF
--- a/lib/factories/plugin.factory.ts
+++ b/lib/factories/plugin.factory.ts
@@ -6,6 +6,7 @@ import {
   makeProcessSchemaPlugin,
   gql } from 'graphile-utils';
 import { ResolverWrapperRequirements } from '../interfaces/wrap-resolver-requirements.interface';
+import { isNil } from 'lodash';
 
 /**
  * Factory for easier creation of PostGraphile plugins
@@ -17,6 +18,13 @@ export class PluginFactory {
     fieldName: string,
     isNullable: boolean,
   ) {
+    if (!typeName || !fieldName) {
+      throw new Error('typeName and fieldName are required for ChangeNullability');
+    }
+
+    typeName = typeName.trim();
+    fieldName = fieldName.trim();
+
     return makeChangeNullabilityPlugin({
       [typeName]: {
         [fieldName]: isNullable,
@@ -31,6 +39,13 @@ export class PluginFactory {
     // tslint:disable-next-line:ban-types
     resolver: Function,
   ) {
+    if (!typeName || !fieldName) {
+      throw new Error('typeName and fieldName are required for WrapResolver');
+    }
+
+    typeName = typeName.trim();
+    fieldName = fieldName.trim();
+
     return makeWrapResolversPlugin({
       [typeName]: {
         [fieldName]: {
@@ -54,6 +69,22 @@ export class PluginFactory {
     resolver: Function,
     additionalGraphql = '',
   ) {
+    if (!typeName || !fieldName || !fieldType) {
+      throw new Error('typeName, fieldName, and fieldType are required for ExtendSchema');
+    }
+
+    typeName = typeName.trim();
+    fieldName = fieldName.trim();
+
+    const matches = fieldName.match(/^\w+/);
+
+    // If no field name exists, then ignore creating the plugin
+    if (isNil(matches)) {
+      throw new Error('Unable to create ExtendSchema plugin because a field name'
+        + ' was not provided or is not in correct form. fieldname: ' + fieldName);
+    }
+
+    const fieldNameWithoutParams = matches[0];
     return makeExtendSchemaPlugin(build => {
       return {
         typeDefs: gql`
@@ -65,7 +96,7 @@ export class PluginFactory {
         `,
         resolvers: {
           [typeName]: {
-            [fieldName]: async (query, args, context, resolveInfo) => {
+            [fieldNameWithoutParams]: async (query, args, context, resolveInfo) => {
               return await resolver(query, args, context, resolveInfo, build);
             },
           },

--- a/tests/helpers/test2-plugin.ts
+++ b/tests/helpers/test2-plugin.ts
@@ -17,4 +17,13 @@ export class Test2Plugin {
   public addName2Field() {
     return 'test2';
   }
+
+  @ExtendSchema({
+    typeName: 'Mutation',
+    fieldName: ' registerUser(input: String!)',
+    fieldType: 'String',
+  })
+  public registerUser(_query: any, args: any, resolveInfo: any, { pgSql: sql }: any) {
+    return 'testing';
+  }
 }

--- a/tests/helpers/test3-plugin.ts
+++ b/tests/helpers/test3-plugin.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { AddInflector, ProcessSchema, ExtendSchema } from '../../lib';
+
+@Injectable()
+export class Test3Plugin {
+
+  @ExtendSchema({
+    typeName: 'Mutation',
+    fieldName: '.registerUser(input: String!)',
+    fieldType: 'String',
+  })
+  public registerUser(_query: any, args: any, resolveInfo: any, { pgSql: sql }: any) {
+    return 'testing';
+  }
+}

--- a/tests/plugin-explorer.spec.ts
+++ b/tests/plugin-explorer.spec.ts
@@ -5,6 +5,7 @@ import { MetadataScanner } from '@nestjs/core/metadata-scanner';
 import { PluginExplorerService } from '../lib/services/plugin-explorer.service';
 import { PluginFactory } from '../lib/factories/plugin.factory';
 import { TestPlugin } from './helpers/test-plugin';
+import { Test3Plugin } from './helpers/test3-plugin';
 
 describe('SchemaTypeExplorerService', () => {
   let pluginExplorerService: PluginExplorerService;
@@ -63,5 +64,18 @@ describe('SchemaTypeExplorerService', () => {
     expect(createExtendSchemaSpy.callCount).toBe(1);
     expect(createProcessSchemaSpy.callCount).toBe(1);
     expect(createAddInflectorsSpy.callCount).toBe(1);
+  });
+
+  it('should throw error on incorrect format for a field with ExtendSchema decorator', async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      providers: [MetadataScanner, PluginExplorerService, Test3Plugin],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    pluginExplorerService = app.get(PluginExplorerService);
+
+    expect(pluginExplorerService.getCombinedPlugin).toThrow();
   });
 });

--- a/tests/postgraphile.module.spec.ts
+++ b/tests/postgraphile.module.spec.ts
@@ -38,7 +38,7 @@ describe('PostGraphileModule', () => {
     const app = moduleFixture.createNestApplication();
     await app.init();
 
-    expect(createExtendSchemaSpy.callCount).toBe(2);
+    expect(createExtendSchemaSpy.callCount).toBe(3);
     expect(createWrapResolverSpy.callCount).toBe(1);
     expect(createChangeNullabilitySpy.callCount).toBe(1);
     expect(createProcessSchemaSpy.callCount).toBe(1);


### PR DESCRIPTION
Fixes issue #12 
- Parameters are now properly stripped out of the string to set the correct format for a Mutation/Query when creating an ExtendSchema plugin in the factory
- Added error checks to ensure the proper decorator properties exists when creating plugins in the factory