### PR TITLE
Added option to not mount postgraphile instance. Instance can be accessed and used on controller path.

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,0 +1,36 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/lib/interfaces/module-options.interface.ts
+++ b/lib/interfaces/module-options.interface.ts
@@ -8,6 +8,7 @@ export interface PGraphileModuleOptions extends PostGraphileOptions {
     schema?: string | string[];
     playground?: boolean;
     playgroundRoute?: string;
+    useAsMiddleware?: boolean;
 }
 
 export interface PGraphileOptionsFactory {

--- a/lib/postgraphile.module.ts
+++ b/lib/postgraphile.module.ts
@@ -12,7 +12,7 @@ import { SchemaTypeExplorerService } from './services/schema-type-explorer.servi
   providers: [MetadataScanner, PluginExplorerService, SchemaTypeExplorerService],
 })
 export class PostGraphileModule implements OnModuleInit {
-
+  private static readonly instances: PostGraphileModule[] = [];
   postgraphile: HttpRequestHandler;
 
   constructor(
@@ -20,7 +20,9 @@ export class PostGraphileModule implements OnModuleInit {
       private readonly pluginExplorerService: PluginExplorerService,
       private readonly schemaTypeExplorerService: SchemaTypeExplorerService,
       @Inject(POSTGRAPHILE_MODULE_OPTIONS) private readonly options: PGraphileModuleOptions,
-  ) {}
+  ) {
+    PostGraphileModule.instances.push(this);
+  }
 
   static forRoot(options: PGraphileModuleOptions): DynamicModule {
     return {
@@ -42,6 +44,10 @@ export class PostGraphileModule implements OnModuleInit {
         ...this.createAsyncProviders(options),
       ],
     };
+  }
+
+  static get Postgraphile(): HttpRequestHandler | undefined {
+    return PostGraphileModule.instances[0]?.postgraphile;
   }
 
   private static createAsyncProviders(
@@ -90,7 +96,7 @@ export class PostGraphileModule implements OnModuleInit {
     const app = httpAdapter.getInstance();
 
     // Break out PostGraphile options
-    const {pgConfig, schema, playground, ...postGraphileOptions} = this.options;
+    const {pgConfig, schema, playground, useAsMiddleware = true, ...postGraphileOptions} = this.options;
 
     const { appendPlugins = [] } = postGraphileOptions;
 
@@ -105,7 +111,9 @@ export class PostGraphileModule implements OnModuleInit {
 
     this.postgraphile = this.createPostGraphql(pgConfig, schema, updatedPostGraphileOptions);
 
-    app.use(this.postgraphile);
+    if (useAsMiddleware) {
+      app.use(this.postgraphile);
+    }
 
     const graphqlRoute = this.options.graphqlRoute ||  '/graphql';
     const playgroundRoute = this.options.playgroundRoute || '/playground';

--- a/lib/postgraphile.module.ts
+++ b/lib/postgraphile.module.ts
@@ -12,6 +12,7 @@ import { SchemaTypeExplorerService } from './services/schema-type-explorer.servi
   providers: [MetadataScanner, PluginExplorerService, SchemaTypeExplorerService],
 })
 export class PostGraphileModule implements OnModuleInit {
+
   private static readonly instances: PostGraphileModule[] = [];
   postgraphile: HttpRequestHandler;
 


### PR DESCRIPTION
Addresses: https://github.com/alex-ald/postgraphile-nest/issues/36

By default, postgraphile is initialized and added as a middleware. NestJS interceptors/guards etc. don't execute on any graphql call.

This PR adds an optional configuration option '**useAsMiddlware**' which is _true by default_, preserving current behavior.
When the value is set to false, postgraphile is only initialized and not mounted as a middleware. User can then call '**PostGraphileModule.Postgraphile**' to access the initialized postgraphile which can be mounted on a path inside a controller. 

Refer: https://www.graphile.org/postgraphile/usage-library/#route-handlers

`
import { Controller, Get, Post, Req, Next, Res } from '@nestjs/common';
import { Request, Response } from 'express';
import { PostGraphileResponseNode } from 'postgraphile';
import { PostGraphileModule } from 'postgraphile-nest';

@Controller('/')
export class PostGraphileController {
  @Post('/graphql')
  graphql (@Req() request: Request, @Res() response: Response, @Next() next) {
    PostGraphileModule.Postgraphile?.graphqlRouteHandler(new PostGraphileResponseNode(request, response, next));
  }
}
`

This way, we can utilize global interceptors/guards/filters etc.